### PR TITLE
Add domain selection, and CloudWatch logs capture

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.ignoreLimitWarning": true
+}

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -903,8 +903,11 @@ Resources:
       TestWebLogsBucket: !Ref TestWebCacheLogs
       FeedbackBucket: !Ref FeedbackData
       UploaderPassword: !Ref UploaderPassword
+      BaseDomain: !GetAtt WebCache.DomainName
+      BaseDomainTest: !GetAtt TestWebCache.DomainName
       {{#domain}}
       DomainName: !Ref DomainName
+      DomainNameTest: !Join ['.', ['test', !Ref DomainName]]
       {{/domain}}
       MaxAgeBrowser: 86400
       MaxAgeCloudFront: 0
@@ -1394,6 +1397,9 @@ Resources:
       UserName: !Ref UploadUser
 
 Outputs:
+  SiteUrl:
+    Description: Base URL for the site which can be used whether there's a custom domain linked or not.
+    Value: !GetAtt WebCache.DomainName
   SharedStorageName:
     Description: Name of the shared bucket. Supply this name as the 'SharedStorageName' parameter when creating other stacks.
     Value: !If [SharedBucket, !Ref SharedData, 'Not Configured']

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -218,6 +218,9 @@ Resources:
     Properties:
       BucketName: !Join ['', [!Ref AWS::StackName, '-logs']]
       AccessControl: Private
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -237,6 +240,9 @@ Resources:
     Properties:
       BucketName: !Join ['.', ['test', !Join ['', [!Ref AWS::StackName, '-logs']]]]
       AccessControl: Private
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -783,7 +789,7 @@ Resources:
       FunctionName: !Join ['-',[!Ref AWS::StackName,'admin-worker']]
       PackageType: Zip
       Runtime: nodejs16.x
-      Role: !GetAtt AdminRole.Arn
+      Role: !GetAtt AdminWorkerRole.Arn
       MemorySize: 1024
       Timeout: 300
       Tags:
@@ -822,7 +828,7 @@ Resources:
       FunctionName: !Join ['-',[!Ref AWS::StackName,'state-pump']]
       PackageType: Zip
       Runtime: nodejs16.x
-      Role: !GetAtt AdminRole.Arn
+      Role: !GetAtt StatePumpRole.Arn
       Timeout: 90
       Tags:
         - Key: 'Service'
@@ -1137,6 +1143,114 @@ Resources:
                  - 'sqs:GetQueueAttributes'
                  - 'sqs:DeleteMessage'
                 Resource: !Join ['', [!Join [':', ['arn:aws:sqs', !Ref AWS::Region, !Ref 'AWS::AccountId', !Ref AWS::StackName]], '*']]
+        - PolicyName: logging
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: 'arn:aws:logs:*:*:*'
+      Tags:
+        - Key: 'Service'
+          Value: !Ref 'AWS::StackName'
+
+  AdminWorkerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Join ['_',[!Ref AWS::StackName,'l-admin-worker']]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - edgelambda.amazonaws.com
+                - events.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: ListS3Resources
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - s3:Get*
+                 - s3:List*
+                 - s3-object-lambda:Get*
+                 - s3-object-lambda:List*
+                Resource: '*'
+        - PolicyName: SharedDataReadWrite
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:PutObject'
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:DeleteObject'
+                 - 's3:GetObjectTagging'
+                 - 's3:PutObjectTagging'
+                Resource: !Join ['', ['arn:aws:s3:::', !If [SharedBucket, !Ref SharedData, !Ref SharedStorageName], '*']]
+        - PolicyName: AdminDataReadWrite
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:PutObject'
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:DeleteObject'
+                 - 's3:GetObjectTagging'
+                 - 's3:PutObjectTagging'
+                Resource: !Join ['', [!GetAtt AdminData.Arn, '*']]
+        - PolicyName: WebDataReadWrite
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:PutObject'
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:DeleteObject'
+                 - 's3:GetObjectTagging'
+                 - 's3:PutObjectTagging'
+                Resource: !Join ['', [!GetAtt WebData.Arn, '*']]
+        - PolicyName: TestWebDataRead
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:GetObjectTagging'
+                Resource: !Join ['', [!GetAtt TestWebData.Arn, '*']]
+        - PolicyName: InvokeWorkerLambdas
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'lambda:InvokeFunction'
+                 - 'lambda:InvokeAsync'
+                Resource: !Join ['', [!Join [':', ['arn:aws:lambda', !Ref AWS::Region, !Ref 'AWS::AccountId', 'function', !Ref AWS::StackName]], '*']]
+        - PolicyName: StatusQueueAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'sqs:SendMessage'
+                Resource: !Join ['', [!Join [':', ['arn:aws:sqs', !Ref AWS::Region, !Ref 'AWS::AccountId', !Ref AWS::StackName]], '*']]
         - PolicyName: CloudFrontAccess
           PolicyDocument:
             Version: 2012-10-17
@@ -1147,7 +1261,13 @@ Resources:
                  - 'cloudfront:GetDistribution'
                  - 'cloudfront:ListDistributions'
                  - 'cloudfront:UpdateDistribution'
-                Resource: !Join [',', [!GetAtt WebCache.Arn, !Join ['', [!GetAtt WebCache.Arn, '*'], !GetAtt TestWebCache.Arn, !Join ['', [!GetAtt TestWebCache.Arn, '*']] ]
+                Resource: !Join
+                  - ','
+                  -
+                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache]]
+                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache, '*']]
+                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache]]
+                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache, '*']]
         - PolicyName: CertificatesAccess
           PolicyDocument:
             Version: 2012-10-17
@@ -1156,6 +1276,118 @@ Resources:
                 Action:
                  - 'acm:ListCertificates'
                 Resource: !Join ['', [!Join [':', ['arn:aws:acm', !Ref AWS::Region, !Ref 'AWS::AccountId', 'certificate']], '*']]
+        - PolicyName: LogsReadAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'logs:DescribeLogStreams'
+                 - 'logs:GetLogEvents'
+                 - 'logs:FilterLogEvents'
+                Resource: !Join ['', [!Join [':', ['arn:aws:logs', !Ref AWS::Region, !Ref 'AWS::AccountId', '']], '*']]
+        - PolicyName: logging
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: 'arn:aws:logs:*:*:*'
+      Tags:
+        - Key: 'Service'
+          Value: !Ref 'AWS::StackName'
+
+  StatePumpRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Join ['_',[!Ref AWS::StackName,'l-state-pump']]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - edgelambda.amazonaws.com
+                - events.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: ListS3Resources
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - s3:Get*
+                 - s3:List*
+                 - s3-object-lambda:Get*
+                 - s3-object-lambda:List*
+                Resource: '*'
+        - PolicyName: SharedDataReadWrite
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:PutObject'
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:DeleteObject'
+                 - 's3:GetObjectTagging'
+                 - 's3:PutObjectTagging'
+                Resource: !Join ['', ['arn:aws:s3:::', !If [SharedBucket, !Ref SharedData, !Ref SharedStorageName], '*']]
+        - PolicyName: AdminDataReadWrite
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:PutObject'
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:DeleteObject'
+                 - 's3:GetObjectTagging'
+                 - 's3:PutObjectTagging'
+                Resource: !Join ['', [!GetAtt AdminData.Arn, '*']]
+        - PolicyName: WebDataReadWrite
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:PutObject'
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:DeleteObject'
+                 - 's3:GetObjectTagging'
+                 - 's3:PutObjectTagging'
+                Resource: !Join ['', [!GetAtt WebData.Arn, '*']]
+        - PolicyName: TestWebDataRead
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 's3:GetObject'
+                 - 's3:ListBucket'
+                 - 's3:GetObjectTagging'
+                Resource: !Join ['', [!GetAtt TestWebData.Arn, '*']]
+        - PolicyName: StatusQueueAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'sqs:ReceiveMessage'
+                 - 'sqs:SendMessage'
+                 - 'sqs:GetQueueAttributes'
+                 - 'sqs:DeleteMessage'
+                Resource: !Join ['', [!Join [':', ['arn:aws:sqs', !Ref AWS::Region, !Ref 'AWS::AccountId', !Ref AWS::StackName]], '*']]
         - PolicyName: logging
           PolicyDocument:
             Version: 2012-10-17

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -899,7 +899,7 @@ Resources:
       Handler: index.handler
       Code:
         S3Bucket: '{{sourceBucket}}'
-        S3Key: 'AutoSite/lambdas/provisioner.zip'
+        S3Key: 'AutoSite{{version}}/lambdas/provisioner.zip'
       Layers:
         - !Ref ProvisionerNMLayer
 

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -1295,7 +1295,7 @@ Resources:
                  - 'logs:DescribeLogStreams'
                  - 'logs:GetLogEvents'
                  - 'logs:FilterLogEvents'
-                Resource: !Join ['', [!Join [':', ['arn:aws:logs', !Ref AWS::Region, !Ref 'AWS::AccountId', '']], '*']]
+                Resource: !Join ['', [!Join [':', ['arn:aws:logs', '*', !Ref 'AWS::AccountId', '']], '*']]
         - PolicyName: logging
           PolicyDocument:
             Version: 2012-10-17

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -882,7 +882,7 @@ Resources:
           Value: !Ref 'AWS::StackName'
       Handler: index.handler
       Code:
-        S3Bucket: 'braevitae-pub'
+        S3Bucket: '{{sourceBucket}}'
         S3Key: 'AutoSite/lambdas/provisioner.zip'
       Layers:
         - !Ref ProvisionerNMLayer
@@ -1134,6 +1134,25 @@ Resources:
                  - 'sqs:GetQueueAttributes'
                  - 'sqs:DeleteMessage'
                 Resource: !Join ['', [!Join [':', ['arn:aws:sqs', !Ref AWS::Region, !Ref 'AWS::AccountId', !Ref AWS::StackName]], '*']]
+        - PolicyName: CloudFrontAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'cloudfront:AssociateAlias'
+                 - 'cloudfront:GetDistribution'
+                 - 'cloudfront:ListDistributions'
+                 - 'cloudfront:UpdateDistribution'
+                Resource: !Join [',', [!GetAtt WebCache.Arn, !Join ['', [!GetAtt WebCache.Arn, '*'], !GetAtt TestWebCache.Arn, !Join ['', [!GetAtt TestWebCache.Arn, '*']] ]
+        - PolicyName: CertificatesAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'acm:ListCertificates'
+                Resource: !Join ['', [!Join [':', ['arn:aws:acm', !Ref AWS::Region, !Ref 'AWS::AccountId', 'certificate']], '*']]
         - PolicyName: logging
           PolicyDocument:
             Version: 2012-10-17

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -1265,22 +1265,28 @@ Resources:
                 Action:
                  - 'sqs:SendMessage'
                 Resource: !Join ['', [!Join [':', ['arn:aws:sqs', !Ref AWS::Region, !Ref 'AWS::AccountId', !Ref AWS::StackName]], '*']]
-        - PolicyName: CloudFrontAccess
+        - PolicyName: CloudFront
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
-                 - 'cloudfront:AssociateAlias'
                  - 'cloudfront:GetDistribution'
                  - 'cloudfront:GetDistributionConfig'
-                 - 'cloudfront:ListDistributions'
                  - 'cloudfront:UpdateDistribution'
                 Resource:
                  - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache]]
                  - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache, '*']]
                  - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache]]
                  - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache, '*']]
+        - PolicyName: CloudFrontList
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'cloudfront:ListDistributions'
+                Resource: '*'
         - PolicyName: CertificatesAccess
           PolicyDocument:
             Version: 2012-10-17

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -914,7 +914,9 @@ Resources:
       AdminBucket: !Ref AdminData
       AdminUiBucket: !Ref AdminUiData
       WebDataBucket: !Ref WebData
+      WebCache: !Ref WebCache
       TestWebDataBucket: !Ref TestWebData
+      TestWebCache: !Ref TestWebCache
       WebLogsBucket: !Ref WebCacheLogs
       TestWebLogsBucket: !Ref TestWebCacheLogs
       FeedbackBucket: !Ref FeedbackData
@@ -923,7 +925,9 @@ Resources:
       BaseDomainTest: !GetAtt TestWebCache.DomainName
       {{#domain}}
       DomainName: !Ref DomainName
+      DomainCertArn: !Ref Certificate
       DomainNameTest: !Join ['.', ['test', !Ref DomainName]]
+      DomainCertTestArn: !Ref TestCertificate
       {{/domain}}
       MaxAgeBrowser: 86400
       MaxAgeCloudFront: 0
@@ -1269,15 +1273,14 @@ Resources:
                 Action:
                  - 'cloudfront:AssociateAlias'
                  - 'cloudfront:GetDistribution'
+                 - 'cloudfront:GetDistributionConfig'
                  - 'cloudfront:ListDistributions'
                  - 'cloudfront:UpdateDistribution'
-                Resource: !Join
-                  - ','
-                  -
-                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache]]
-                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache, '*']]
-                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache]]
-                    - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache, '*']]
+                Resource:
+                 - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache]]
+                 - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref WebCache, '*']]
+                 - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache]]
+                 - !Join ['', ['arn:aws:cloudfront::', !Ref 'AWS::AccountId', ':distribution/', !Ref TestWebCache, '*']]
         - PolicyName: CertificatesAccess
           PolicyDocument:
             Version: 2012-10-17
@@ -1285,6 +1288,15 @@ Resources:
               - Effect: Allow
                 Action:
                  - 'acm:ListCertificates'
+                Resource: '*'
+        - PolicyName: Route53
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                 - 'route53:ListHostedZones'
+                 - 'route53:ChangeResourceRecordSets'
                 Resource: '*'
         - PolicyName: LogsReadAccess
           PolicyDocument:
@@ -1415,7 +1427,7 @@ Resources:
   ProvisionerRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Join ['_',[!Ref AWS::StackName,'l-provison']]
+      RoleName: !Join ['_',[!Ref AWS::StackName,'l-provision']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/AuthorSite.template.handlebars
+++ b/AuthorSite.template.handlebars
@@ -422,6 +422,11 @@ Resources:
             ViewerProtocolPolicy: allow-all
             ForwardedValues:
               QueryString: false
+          - PathPattern: /logs/*
+            TargetOriginId: AdminUiData
+            ViewerProtocolPolicy: allow-all
+            ForwardedValues:
+              QueryString: false
         CustomErrorResponses:
           - ErrorCachingMinTTL: 300
             ErrorCode: 403
@@ -542,6 +547,11 @@ Resources:
                 LambdaFunctionARN: !Ref OnCacheVersion
                 IncludeBody: true
           - PathPattern: /content/*
+            TargetOriginId: AdminUiData
+            ViewerProtocolPolicy: allow-all
+            ForwardedValues:
+              QueryString: false
+          - PathPattern: /logs/*
             TargetOriginId: AdminUiData
             ViewerProtocolPolicy: allow-all
             ForwardedValues:
@@ -1275,7 +1285,7 @@ Resources:
               - Effect: Allow
                 Action:
                  - 'acm:ListCertificates'
-                Resource: !Join ['', [!Join [':', ['arn:aws:acm', !Ref AWS::Region, !Ref 'AWS::AccountId', 'certificate']], '*']]
+                Resource: '*'
         - PolicyName: LogsReadAccess
           PolicyDocument:
             Version: 2012-10-17

--- a/admin/index.js
+++ b/admin/index.js
@@ -759,8 +759,15 @@ async function updateDistributionDomain(cfDistId, domain, certArn) {
   resp.DistributionConfig.Aliases.Items = [domain, 'www.' + domain]
   resp.DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = false
   resp.DistributionConfig.ViewerCertificate.ACMCertificateArn = certArn
+  //
+  if (resp.DistributionConfig.ViewerCertificate.SSLSupportMethod === 'vip') {
+    console.log("AWS Bug!!!: SSLSupportMethod === 'vip', which is NEVER intentonally enabled! Force back to 'sni-only'.")
+  }
+  resp.DistributionConfig.ViewerCertificate.SSLSupportMethod = 'sni-only'
+  //
   resp.IfMatch = resp.ETag
   delete resp.ETag
+  //
   resp.Id = cfDistId
   await aws.cf.updateDistribution(resp).promise()
 }
@@ -791,8 +798,15 @@ async function clearDistributionDomain(cfDistId) {
   resp.DistributionConfig.Aliases.Items = []
   resp.DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = true
   resp.DistributionConfig.ViewerCertificate.ACMCertificateArn = null
+  //
+  if (resp.DistributionConfig.ViewerCertificate.SSLSupportMethod === 'vip') {
+    console.log("AWS Bug!!!: SSLSupportMethod === 'vip', which is NEVER intentonally enabled! Force back to 'sni-only'.")
+  }
+  resp.DistributionConfig.ViewerCertificate.SSLSupportMethod = 'sni-only'
+  //
   resp.IfMatch = resp.ETag
   delete resp.ETag
+  //
   resp.Id = cfDistId
   await aws.cf.updateDistribution(resp).promise()
 }

--- a/admin/index.js
+++ b/admin/index.js
@@ -743,9 +743,8 @@ async function upsertCustomDomain(hostedZoneId, domains, newDomain) {
   await execR53Changes(hostedZoneId, [createUpsertChange('www.' + newDomain.testDomain, domains.baseTest, 'A')])
   await execR53Changes(hostedZoneId, [createUpsertChange(newDomain.testDomain, domains.baseTest, 'AAAA')])
   await execR53Changes(hostedZoneId, [createUpsertChange('www.' + newDomain.testDomain, domains.baseTest, 'AAAA')])
-  // Update CF Ditros domain aliases and certificates. Add a pause since AWS will only allow one dist. cert change at a time.
+  // Update CF Ditros domain aliases and certificates.
   await updateDistributionDomain(domains.dist, newDomain.domain, newDomain.arn)
-  await sleep(1)
   await updateDistributionDomain(domains.distTest, newDomain.testDomain, newDomain.testArn)
 }
 
@@ -779,9 +778,8 @@ async function removeCustomDomain(hostedZoneId, domains) {
     await execR53Changes(hostedZoneId, [createDeleteChange(domains.currentTest, domains.baseTest, 'AAAA')])
     await execR53Changes(hostedZoneId, [createDeleteChange('www.' + domains.currentTest, domains.baseTest, 'AAAA')])
   }
-  // Remove alt domain names and custom cert from old CF. Add a pause since AWS will only allow one dist. cert change at a time.
+  // Remove alt domain names and custom cert from old CF.
   await clearDistributionDomain(domains.dist)
-  await sleep(1)
   await clearDistributionDomain(domains.distTest)
 }
 

--- a/admin/index.js
+++ b/admin/index.js
@@ -759,10 +759,8 @@ async function updateDistributionDomain(cfDistId, domain, certArn) {
   resp.DistributionConfig.Aliases.Items = [domain, 'www.' + domain]
   resp.DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = false
   resp.DistributionConfig.ViewerCertificate.ACMCertificateArn = certArn
-  //
-  if (resp.DistributionConfig.ViewerCertificate.SSLSupportMethod === 'vip') {
-    console.log("AWS Bug!!!: SSLSupportMethod === 'vip', which is NEVER intentonally enabled! Force back to 'sni-only'.")
-  }
+  // AWS Sets Legacy Client Support (SSLSupportMethod === 'vip') when using the CloudFront default certificate, but does
+  // not set it back to sni-only when a custome cert is added, so we need to ensure it's set back manually.
   resp.DistributionConfig.ViewerCertificate.SSLSupportMethod = 'sni-only'
   //
   resp.IfMatch = resp.ETag
@@ -798,11 +796,6 @@ async function clearDistributionDomain(cfDistId) {
   resp.DistributionConfig.Aliases.Items = []
   resp.DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = true
   resp.DistributionConfig.ViewerCertificate.ACMCertificateArn = null
-  //
-  if (resp.DistributionConfig.ViewerCertificate.SSLSupportMethod === 'vip') {
-    console.log("AWS Bug!!!: SSLSupportMethod === 'vip', which is NEVER intentonally enabled! Force back to 'sni-only'.")
-  }
-  resp.DistributionConfig.ViewerCertificate.SSLSupportMethod = 'sni-only'
   //
   resp.IfMatch = resp.ETag
   delete resp.ETag

--- a/admin/index.js
+++ b/admin/index.js
@@ -65,7 +65,7 @@ const aws = new AwsUtils({
   sqs: new sdk.SQS(),
   stateQueueUrl: stateQueueUrl,
   cf: new sdk.CloudFront(),
-  cm: new sdk.ACM(),
+  acm: new sdk.ACM(),
   r53: new sdk.Route53(),
   logs: new sdk.CloudWatchLogs()
 })

--- a/admin/index.js
+++ b/admin/index.js
@@ -886,7 +886,7 @@ async function captureLogs(adminBucket, options) {
       eventMsgs.push(displayTs + ' ' + event.group.padEnd(MaxGroupNameLength, ' ') + ' ' + event.message)
     })
     const endTsFmt = new Date(endTs).toISOString()
-    aws.put(adminUiBucket, 'logs/log-' + endTsFmt, 'application/octet-stream', eventMsgs.join('\n'), 0, 0)
+    aws.put(adminUiBucket, 'logs/log-' + endTsFmt + '.log', 'application/octet-stream', eventMsgs.join('\n'), 0, 0)
     await aws.displayUpdate({ getLogs: false, getLogsError: false, getLogsErrMsg: '' }, 'getLogs', 'AWS Logs ready for download.')
   } catch (e) {
     await aws.displayUpdate({ getLogs: false, getLogsError: true, getLogsErrMsg: `Failed to get AWS logs: ${e.message}` }, 'getLogs', 'Error: Failed to get AWS Logs.')

--- a/admin/index.js
+++ b/admin/index.js
@@ -25,7 +25,9 @@ const aws = new AwsUtils({
   files: Files,
   s3: new sdk.S3(),
   sqs: new sdk.SQS(),
-  stateQueueUrl: stateQueueUrl
+  stateQueueUrl: stateQueueUrl,
+  cf: new sdk.CloudFront(),
+  cm: new sdk.ACM()
 })
 
 /** Worker for admin tasks forwarded from admin@Edge lambda.
@@ -60,6 +62,10 @@ exports.handler = async (event, _context) => {
       return saveTemplate(sharedBucket, adminBucket, event.body)
     case 'setPassword':
       return setPassword(adminBucket, event.body)
+    case 'getAvailableDomains':
+      return getAvailableDomains(adminBucket, event.body)
+    case 'setSiteDomain':
+      return setSiteDomain(adminBucket, event.body)
     default:
       return {
         status: '404',
@@ -609,5 +615,37 @@ async function setPassword(adminBucket, params) {
   } catch (e) {
     console.log(`Failed to set new password.`, e)
     await aws.displayUpdate({ settingPwd: false, setPwdError: true, setPwdErrMsg: `Failed to change password ${e.message}` }, 'changePassword', `End change password. Failed: ${e.message}`)
+  }
+}
+
+async function getAvailableDomains(adminBucket, params) {
+  try {
+    await aws.displayUpdate({ getDomains: true, getDomError: false, getDomErrMsg: '' }, 'getDomains', `Start get available domains`)
+
+    // Get all avaiable certificates that qualify - must have a main and test site, or be a wildcard cert
+
+
+
+
+    // Get all certs in use from CF, and remove from available list
+
+
+    await aws.displayUpdate({ getDomains: false, getDomError: false, getDomErrMsg: '' }, 'getDomains', `End get available domains`)
+  } catch (e) {
+    console.log(`Failed to get available domains.`, e)
+    await aws.displayUpdate({ getDomains: false, getDomError: true, getDomErrMsg: `Failed to get domains ${e.message}` }, 'getDomains', `End get available domains. Failed: ${e.message}`)
+  }
+}
+
+async function setSiteDomain(adminBucket, params) {
+  try {
+    await aws.displayUpdate({ setDomain: true, setDomError: false, setDomErrMsg: '' }, 'setDomain', `Start set domain`)
+
+
+
+    await aws.displayUpdate({ setDomains: false, setDomError: false, setDomErrMsg: '' }, 'setDomain', `End set domain`)
+  } catch (e) {
+    console.log(`Failed to set domain.`, e)
+    await aws.displayUpdate({ setDomains: false, setDomError: true, setDomErrMsg: `Failed to set domain ${e.message}` }, 'setDomain', `End set domain. Failed: ${e.message}`)
   }
 }

--- a/admin/index.js
+++ b/admin/index.js
@@ -672,6 +672,7 @@ async function getAvailableDomains(_params) {
     const validDomains = []
     const allFreeCerts = await aws.listCertificates()
     allFreeCerts.map(cert => {
+      // Pair each cert with its test cert (all valid domains will come in domain and test pairs.)
       const testCert = allFreeCerts.find(p => p.domain === ('test.' + cert.domain))
       if (testCert) {
         validDomains.push({
@@ -685,6 +686,10 @@ async function getAvailableDomains(_params) {
     // Send event to update admin state
     aws.updateAvailableDomains(validDomains)
     await aws.displayUpdate({ getDomains: false, getDomError: false, getDomErrMsg: '' }, 'getDomains', `End get available domains`)
+    return {
+      status: '200',
+      statusDescription: `Found ${validDomains.length} domains.`
+    }
   } catch (e) {
     console.log(`Failed to get available domains.`, e)
     await aws.displayUpdate({ getDomains: false, getDomError: true, getDomErrMsg: `Failed to get domains ${e.message}` }, 'getDomains', `End get available domains. Failed: ${e.message}`)

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "bundleDependencies": [
         "@aws-sdk/client-s3",
+        "fast-deep-equal",
         "fs-extra",
         "handlebars",
         "md5-file",
@@ -16,12 +17,14 @@
         "path",
         "s3-sync-client",
         "unzipper",
+        "uuid",
         "yaml",
         "zip-a-folder"
       ],
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.190.0",
+        "fast-deep-equal": "^3.1.3",
         "fs-extra": "^11.1.1",
         "handlebars": "^4.7.7",
         "md5-file": "^5.0.0",
@@ -30,6 +33,7 @@
         "s3-sync-client": "^3.0.3",
         "textile-js": "^0.1.11",
         "unzipper": "^0.10.11",
+        "uuid": "^9.0.1",
         "yaml": "^2.1.3",
         "zip-a-folder": "^1.1.5"
       },
@@ -778,6 +782,15 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "inBundle": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
@@ -2657,7 +2670,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "inBundle": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4738,9 +4751,13 @@
       "inBundle": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "inBundle": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -5911,6 +5928,13 @@
         "@aws-sdk/util-middleware": "3.190.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
@@ -7309,8 +7333,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -8849,9 +8872,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "walkdir": {
       "version": "0.0.11",

--- a/admin/package.json
+++ b/admin/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.190.0",
+    "fast-deep-equal": "^3.1.3",
     "fs-extra": "^11.1.1",
     "handlebars": "^4.7.7",
     "md5-file": "^5.0.0",
@@ -33,11 +34,13 @@
     "s3-sync-client": "^3.0.3",
     "textile-js": "^0.1.11",
     "unzipper": "^0.10.11",
+    "uuid": "^9.0.1",
     "yaml": "^2.1.3",
     "zip-a-folder": "^1.1.5"
   },
   "bundleDependencies": [
     "@aws-sdk/client-s3",
+    "fast-deep-equal",
     "fs-extra",
     "handlebars",
     "md5-file",
@@ -45,6 +48,7 @@
     "path",
     "s3-sync-client",
     "unzipper",
+    "uuid",
     "yaml",
     "zip-a-folder"
   ]

--- a/admin/statePump.js
+++ b/admin/statePump.js
@@ -22,5 +22,5 @@ exports.handler = async (_event, _context) => {
   if (lock) {
     console.log(`State locked by ${lock.id}, skipping this update.`)
   }
-  await aws.updateAdminStateFromQueue({}, adminBucket, adminUiBucket, { deleteOldLogs: true })
+  await aws.updateAdminStateFromQueue(adminBucket, adminUiBucket, { deleteOldLogs: true })
 }

--- a/adminUi/package-lock.json
+++ b/adminUi/package-lock.json
@@ -6768,9 +6768,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001473",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
-      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
+      "version": "1.0.30001574",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001574.tgz",
+      "integrity": "sha512-BtYEK4r/iHt/txm81KBudCUcTy7t+s9emrIaHqjYurQ10x71zJ5VQ9x1dYPcz/b+pKSp4y/v1xSI67A+LzpNyg==",
       "funding": [
         {
           "type": "opencollective",
@@ -23484,9 +23484,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001473",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
-      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg=="
+      "version": "1.0.30001574",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001574.tgz",
+      "integrity": "sha512-BtYEK4r/iHt/txm81KBudCUcTy7t+s9emrIaHqjYurQ10x71zJ5VQ9x1dYPcz/b+pKSp4y/v1xSI67A+LzpNyg=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/adminUi/package.json
+++ b/adminUi/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "homepage": ".",
-  "proxy": "http://demo2.braevitae.com:80",
+  "proxy": "http://d3qxvdlnz0x0x6.cloudfront.net:80",
   "jest": {
     "transformIgnorePatterns": [
       "node_modules/(?!strip-json-comments)"

--- a/adminUi/package.json
+++ b/adminUi/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "homepage": ".",
-  "proxy": "http://braevitae.com:80",
+  "proxy": "http://demo3.braevitae.com:80",
   "jest": {
     "transformIgnorePatterns": [
       "node_modules/(?!strip-json-comments)"

--- a/adminUi/package.json
+++ b/adminUi/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "homepage": ".",
-  "proxy": "http://demo3.braevitae.com:80",
+  "proxy": "http://demo2.braevitae.com:80",
   "jest": {
     "transformIgnorePatterns": [
       "node_modules/(?!strip-json-comments)"

--- a/adminUi/src/ActionButton.js
+++ b/adminUi/src/ActionButton.js
@@ -5,7 +5,7 @@ import {
 
 /**  */
 export default function ActionButton({
-    id, text, onClick, tooltip, errorFlag, errorText, buttonStyle, disabled, isLoading, loadingText
+    id, text, onClick, w, tooltip, errorFlag, errorText, buttonStyle, disabled, isLoading, loadingText
   }) {
   id = id || text
   buttonStyle = buttonStyle || {}
@@ -16,7 +16,7 @@ export default function ActionButton({
       openDelay={tooltip.openDelay || 650} closeDelay={tooltip.closeDelay || 250} hasArrow={true} placement={tooltip.placement}
       label={errorFlag ? errorText : tooltip.text} aria-label={errorFlag ? errorText : tooltip.text}
     >
-      <Button key={id + '-btn'} onClick={onClick}
+      <Button key={id + '-btn'} onClick={onClick} w={w}
           size={buttonStyle.size || 'sm'} h={buttonStyle.height} m={buttonStyle.margin || '0 0.5em'}
           color='accent' _hover={{ bg: 'gray.400' }} bg={errorFlag ? 'danger' : 'accentText'}
           disabled={disabled} isLoading={isLoading} loadingText={loadingText}

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -185,7 +185,7 @@ function App() {
     }
     // If the selected domain is the CF base domain, then _remove_ the custom domain, otherwise,
     // change/add custom domain.
-    if (domain.domain === domains.current.base) {
+    if (domain.domain === adminDomains.current.base) {
       controller.sendCommand('setDomain', { domains: adminDomains.current })
     } else {
       controller.sendCommand('setDomain', { domains: adminDomains.current, newDomain: domain })

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -381,7 +381,7 @@ function App() {
       if (adminState.domains) {
         adminDomains.current = adminState.domains
       }
-      if (adminState.availableDomains && adminState.availableDomains.length) {
+      if (adminState.availableDomains && adminState.availableDomains.length !== undefined) {
         const domains = [{
             domain: adminState.domains.current,
             arn: adminState.domains.currentArn,
@@ -413,6 +413,18 @@ function App() {
         if (activeStates.length === 0) {
           endFastPolling()
         }
+        if (showChangingDomain && adminState.display.setDomain === false) {
+          setShowChangingDomain(false)
+          // Clear available domains so it will get re-set to the current admin state. This will ensure the dropdown list
+          // and it's active selection is kept up to date.
+          setAvailableDomains([])
+          // Check for, and dispay error conditions?
+          // ??
+
+          // Check for any CF operations in progress for main or test distro?
+             // Grey-out the domain selection dropdown if in progress.
+
+        }
       }
       if ( ! deepEqual(adminState.templates, adminTemplates)) {
         setAdminTemplates(adminState.templates)
@@ -423,14 +435,13 @@ function App() {
           if (adminDomains.current.current !== window.location.host && window.location.host !== adminState.domains.base) {
             if (showChangingDomain) {
               // Upate browser location to match expected domain in adminConfig
-              setShowChangingDomain(false)
               window.location.host = adminDomains.current.current
             }
           }
         }
       }
       if ( ! deepEqual(adminState.availableDomains, availableDomains)) {
-        if (adminState.availableDomains && adminState.availableDomains.length) {
+        if (adminState.availableDomains && adminState.availableDomains.length !== undefined) {
           const domains = [{
               domain: adminState.domains.current,
               arn: adminState.domains.currentArn,

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -177,12 +177,15 @@ function App() {
   const advancedModeClick = () => setAdvancedMode(!advancedMode)
 
   const setDomain = (domain) => {
-    controller.sendCommand('setDomain', { domain: domain })
     if (siteHost !== adminDomains.current.base) {
       // Current location is NOT the base (default CF domain), so the site will be unstable while
       // the swap is happening and we'll need to refresh the browser to the new domain.
       startFastPolling()
       setShowChangingDomain(true)
+      //
+      controller.sendCommand('setDomain', { })
+    } else {
+      controller.sendCommand('setDomain', { domain: domain })
     }
   }
 
@@ -345,8 +348,11 @@ function App() {
       setAdminConfig(adminState.config)
       setAdminTemplates(adminState.templates)
       adminDisplay.current = adminState.display
+
+
       //adminDomains.current = adminState.domains
       //availableDomains.current = adminState.availableDomains
+
 
       // Testing
       adminDomains.current = {
@@ -359,6 +365,7 @@ function App() {
         'BaseDomain',
         'DomainName'
       ]
+      // Testing
 
 
       if (adminState.config.templateId) {
@@ -512,6 +519,9 @@ function App() {
             >
               <Select size='sm' m='2px' border='none' color='accentText'
                 defaultValue={availableDomains.current.indexOf(adminDomains.current.current)} disabled={locked}
+                onFocus={async ev => {
+                  await controller.sendCommand('getAvailableDomains')
+                }}
                 onChange={ev => {
                   setDomain(availableDomains.current[ev.target.value])
                 }}
@@ -694,6 +704,8 @@ function useAdminStatePolling(adminLive, setAdminState) {
       //console.log(`First admin state`)
       setAdminState(controller.getConfig())
     })
+    // Sneak in a call here to pre-load the list of available domains.
+    controller.sendCommand('getAvailableDomains')
   }
   useEffect(() => {
     if ( ! adminStatePoller) {

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -415,9 +415,6 @@ function App() {
       if (adminState.domains) {
         adminDomains.current = adminState.domains
       }
-      if (adminState.availableDomains && adminState.availableDomains.length !== undefined) {
-        setAvailableDomains(adminState.availableDomains.filter(p => p.domain !== adminState.domains.current))
-      }
       if (adminState.config.templateId) {
         currTemplate.current = adminState.templates.find(t => t.id === adminState.config.templateId)
       }
@@ -458,11 +455,6 @@ function App() {
           adminDomains.current = adminState.domains
         }
       }
-      if ( ! deepEqual(adminState.availableDomains, availableDomains)) {
-        if (adminState.availableDomains && adminState.availableDomains.length !== undefined) {
-          setAvailableDomains(adminState.availableDomains.filter(p => p.domain !== adminState.domains.current))
-        }
-      }
       if ( ! deepEqual(adminState.capturedLogs, capturedLogs)) {
         if (adminState.capturedLogs && adminState.capturedLogs.length !== undefined) {
           setCapturedLogs(adminState.capturedLogs)
@@ -470,23 +462,26 @@ function App() {
         }
       }
     }
-    // Ensure the current and base domains are in the domains list, even if no others.
-    if (adminState.domains) {
+    // Update available domains
+    //    Ensure the current and base domains are in the domains list, even if no others.
+    if (adminState.domains && adminState.availableDomains) {
+      const domains = [...adminState.availableDomains]
       if (adminState.domains.current) {
-        availableDomains.unshift({
+        domains.unshift({
           domain: adminState.domains.current,
           arn: adminState.domains.currentArn,
           testDomain: adminState.domains.currentTest,
           testArn: adminState.domains.currentTestArn
         })
       }
-      if (adminState.domains.base) {
-        availableDomains.push({
+      if (adminState.domains.base && adminState.domains.base !== adminState.domains.current) {
+        domains.push({
           domain: adminState.domains.base,
           testDomain: adminState.domains.baseTest,
           listName: adminState.domains.base + ((adminState.domains.current !== adminState.domains.base) ? ' (Browser will reload)' : '')
         })
       }
+      setAvailableDomains(domains)
     }
   }
 

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -207,9 +207,9 @@ function App() {
     // If the selected domain is the CF base domain, then _remove_ the custom domain, otherwise,
     // change/add custom domain.
     if (domain.domain === adminDomains.current.base) {
-      controller.sendCommand('setDomain', { domains: adminDomains.current })
+      controller.sendCommand('setSiteDomain', { domains: adminDomains.current })
     } else {
-      controller.sendCommand('setDomain', { domains: adminDomains.current, newDomain: domain })
+      controller.sendCommand('setSiteDomain', { domains: adminDomains.current, newDomain: domain })
     }
   }
 
@@ -383,8 +383,17 @@ function App() {
       }
       if (adminState.availableDomains && adminState.availableDomains.length) {
         availableDomains.current = adminState.availableDomains
-        // Always add base domain:
-        availableDomains.current.push(adminState.domains.base)
+        // Always add current domain at top, and base domain at bottom
+        availableDomains.current.unshift({
+          domain: adminState.domains.current,
+          arn: adminState.domains.currentArn,
+          testDomain: adminState.domains.currentTest,
+          testArn: adminState.domains.currentTestArn
+        })
+        availableDomains.current.push({
+          domain: adminState.domains.base,
+          testDomain: adminState.domains.baseTest,
+        })
       }
       if (adminState.config.templateId) {
         currTemplate.current = adminState.templates.find(t => t.id === adminState.config.templateId)
@@ -423,8 +432,17 @@ function App() {
       if ( ! deepEqual(adminState.availableDomains, availableDomains.current)) {
         if (adminState.availableDomains && adminState.availableDomains.length) {
           availableDomains.current = adminState.availableDomains
-          // Always add base domain:
-          availableDomains.current.push(adminState.domains.base)
+          // Always add current domain at top, and base domain at bottom
+          availableDomains.current.unshift({
+            domain: adminState.domains.current,
+            arn: adminState.domains.currentArn,
+            testDomain: adminState.domains.currentTest,
+            testArn: adminState.domains.currentTestArn
+          })
+          availableDomains.current.push({
+            domain: adminState.domains.base,
+            testDomain: adminState.domains.baseTest,
+          })
         }
       }
       if ( ! deepEqual(adminState.capturedLogs, capturedLogs.current)) {
@@ -559,7 +577,9 @@ function App() {
               label={LIST_DOMAIN_TOOLTIP}
             >
               <Select size='sm' m='2px' border='none' color='accentText'
-                defaultValue={availableDomains.current ? availableDomains.current.indexOf(adminDomains.current.current) : null} disabled={locked}
+                // Current domain should always be first in list
+                //defaultValue={availableDomains.current ? availableDomains.current.indexOf(adminDomains.current.current) : null}
+                disabled={locked}
                 onFocus={async ev => {
                   await controller.sendCommand('getAvailableDomains')
                 }}

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -75,6 +75,7 @@ const BUTTON_PUBLISH_TOOLTIP = 'Replace your current live site content with the 
 const BUTTON_UPDATE_TEMPLATE_TOOLTIP = 'Update to the latest template without impacting your site configuration.'
 const BUTTON_UPDATE_UI_TOOLTIP = 'Update to the latest Admin UI version. The current version will be backed up at /restore/index'
 const LIST_DOMAIN_TOOLTIP = 'Set Site domain. The browser page may reload if this setting is changed.'
+const LIST_DOMAIN_TOOLTIP_UPDATING = 'The domain name can not be changed while AWS is currently updating this site.'
 const BUTTON_LOAD_TEMPLATE = 'DANGER! Load a new template, completely replacing all existing configuraton settings. This is an advanced feature for template debugging, only use it if you are cetain it is needed'
 const BUTTON_SAVE_TEMPLATE = 'Save all current configuraton settings to a new template bundle.'
 const BUTTON_SET_PASSWORD = 'Change the site admin password'
@@ -158,6 +159,7 @@ function App() {
   const [uploadError, setUploadError] = useState(null)
   const [capturedLogs, setCapturedLogs] = useState([])
   const [availableDomains, setAvailableDomains] = useState([])
+  const [cfDistUpdating, setCfDistUpdating] = useState(false)
 
   // Calculated State
   const authenticated = authState === 'success'
@@ -378,6 +380,7 @@ function App() {
       setAdminConfig(adminState.config)
       setAdminTemplates(adminState.templates)
       adminDisplay.current = adminState.display
+      setCfDistUpdating(adminDisplay.current.cfDistUpdating)
       if (adminState.domains) {
         adminDomains.current = adminState.domains
       }
@@ -425,6 +428,8 @@ function App() {
              // Grey-out the domain selection dropdown if in progress.
 
         }
+        console.log(`cfDistUpdating? ` + adminDisplay.current.cfDistUpdating)
+        setCfDistUpdating(adminDisplay.current.cfDistUpdating)
       }
       if ( ! deepEqual(adminState.templates, adminTemplates)) {
         setAdminTemplates(adminState.templates)
@@ -584,11 +589,11 @@ function App() {
             <Text color='danger' whiteSpace='nowrap' m='2px' hidden={!locked}>(Read Only)</Text>
             <Spacer m='3px'/>
             <Tooltip
-              openDelay={650} closeDelay={250} hasArrow={true} placement='bottom-end'
-              label={LIST_DOMAIN_TOOLTIP}
+              openDelay={1050} closeDelay={250} hasArrow={true} placement='bottom-end'
+              label={cfDistUpdating ? LIST_DOMAIN_TOOLTIP_UPDATING : LIST_DOMAIN_TOOLTIP}
             >
               <Select size='sm' m='2px' border='none' color='accentText'
-                disabled={locked}
+                disabled={locked || cfDistUpdating}
                 onFocus={async ev => {
                   await controller.sendCommand('getAvailableDomains')
                 }}

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -78,8 +78,9 @@ const LIST_DOMAIN_TOOLTIP = 'Set Site domain. The browser page may reload if thi
 const BUTTON_LOAD_TEMPLATE = 'DANGER! Load a new template, completely replacing all existing configuraton settings. This is an advanced feature for template debugging, only use it if you are cetain it is needed'
 const BUTTON_SAVE_TEMPLATE = 'Save all current configuraton settings to a new template bundle.'
 const BUTTON_SET_PASSWORD = 'Change the site admin password'
-const BUTTON_CAPTURE_LOGS = 'Capture the last 1 hour of logs to a doanloadable text file.'
-const BUTTON_DOWNLOAD_LOGS = 'Captured log files available for download. Log files will be removed 1 hour after capture.'
+const BUTTON_CAPTURE_LOGS = 'Capture the last 1 hour of logs to a text file.'
+const BUTTON_DOWNLOAD_LOGS_1 = 'Captured log files available for download.'
+const BUTTON_DOWNLOAD_LOGS_2 = 'Log files will be removed 1 hour after capture.'
 
 // Drive controller logic at a rate set by the UI:
 // Check state as needed (variable rate)
@@ -160,12 +161,6 @@ function App() {
   const newPassword = useRef({})
   const availableDomains = useRef([])
   const capturedLogs = useRef([])
-
-  // DEBUG
-  //capturedLogs.current.push({ name: '2024-12-08T14:15:04Z', url: '/logs/log-2024-12-08T14:15:04Z.log' })
-  //capturedLogs.current.push({ name: '2024-12-08T14:10:04Z', url: '/logs/log-2024-12-08T14:10:04Z.log' })
-
-  // END DEBUG
 
   // Indicate there's new content to put on this path
   const scheduleContentPush = (path, source, id, editorId) => {
@@ -375,6 +370,9 @@ function App() {
       if (adminState.config.templateId) {
         currTemplate.current = adminState.templates.find(t => t.id === adminState.config.templateId)
       }
+      if (adminState.capturedLogs) {
+        capturedLogs.current = adminState.capturedLogs
+      }
       setAdminLive(true)
     } else {
       if ( ! deepEqual(adminState.config, adminConfig)) {
@@ -407,6 +405,11 @@ function App() {
       if ( ! deepEqual(adminState.availableDomains, availableDomains.current)) {
         if (adminState.availableDomains && adminState.availableDomains.length) {
           availableDomains.current = adminState.availableDomains
+        }
+      }
+      if ( ! deepEqual(adminState.capturedLogs, capturedLogs.current)) {
+        if (adminState.capturedLogs && adminState.capturedLogs.length) {
+          capturedLogs.current = adminState.capturedLogs
         }
       }
     }
@@ -625,12 +628,13 @@ function App() {
                     <PopoverContent>
                       <PopoverArrow />
                       <PopoverBody>
-                        <Text>{adminDisplay.setPwdError ? BUTTON_DOWNLOAD_LOGS + '\n\n' + adminDisplay.setPwdErrMsg : BUTTON_DOWNLOAD_LOGS}</Text>
-                        <VStack margin='0.5em 0'>
+                        <Text>{BUTTON_DOWNLOAD_LOGS_1}</Text>
+                        <VStack spacing={0} align='stretch' margin='0.5em 0'>
                           {capturedLogs.current.map(logFile => {
-                            return <Link href="{logFile.url}">{logFile.name}</Link>
+                            return <Link key={logFile.url} href={logFile.url} target='_blank'>{logFile.name}</Link>
                           })}
                         </VStack>
+                        <Text>{BUTTON_DOWNLOAD_LOGS_2}</Text>
                       </PopoverBody>
                     </PopoverContent>
                   </Portal></>

--- a/adminUi/src/App.js
+++ b/adminUi/src/App.js
@@ -156,6 +156,8 @@ function App() {
   const [path, setPath] = useState([])
   const [contentToGet, setContentToGet] = useState(null)
   const [uploadError, setUploadError] = useState(null)
+  const [capturedLogs, setCapturedLogs] = useState([])
+  const [availableDomains, setAvailableDomains] = useState([])
 
   // Calculated State
   const authenticated = authState === 'success'
@@ -173,8 +175,6 @@ function App() {
   const saveTemplateName = useRef({})
   const saveTemplateDesc = useRef({})
   const newPassword = useRef({})
-  const availableDomains = useRef([])
-  const capturedLogs = useRef([])
 
   // Indicate there's new content to put on this path
   const scheduleContentPush = (path, source, id, editorId) => {
@@ -382,24 +382,24 @@ function App() {
         adminDomains.current = adminState.domains
       }
       if (adminState.availableDomains && adminState.availableDomains.length) {
-        availableDomains.current = adminState.availableDomains
-        // Always add current domain at top, and base domain at bottom
-        availableDomains.current.unshift({
-          domain: adminState.domains.current,
-          arn: adminState.domains.currentArn,
-          testDomain: adminState.domains.currentTest,
-          testArn: adminState.domains.currentTestArn
-        })
-        availableDomains.current.push({
-          domain: adminState.domains.base,
-          testDomain: adminState.domains.baseTest,
-        })
+        const domains = [{
+            domain: adminState.domains.current,
+            arn: adminState.domains.currentArn,
+            testDomain: adminState.domains.currentTest,
+            testArn: adminState.domains.currentTestArn
+          },
+          ...adminState.availableDomains,
+          {
+            domain: adminState.domains.base,
+            testDomain: adminState.domains.baseTest,
+          }]
+        setAvailableDomains(domains)
       }
       if (adminState.config.templateId) {
         currTemplate.current = adminState.templates.find(t => t.id === adminState.config.templateId)
       }
       if (adminState.capturedLogs) {
-        capturedLogs.current = adminState.capturedLogs
+        setCapturedLogs(adminState.capturedLogs)
       }
       setAdminLive(true)
     } else {
@@ -429,25 +429,25 @@ function App() {
           }
         }
       }
-      if ( ! deepEqual(adminState.availableDomains, availableDomains.current)) {
+      if ( ! deepEqual(adminState.availableDomains, availableDomains)) {
         if (adminState.availableDomains && adminState.availableDomains.length) {
-          availableDomains.current = adminState.availableDomains
-          // Always add current domain at top, and base domain at bottom
-          availableDomains.current.unshift({
-            domain: adminState.domains.current,
-            arn: adminState.domains.currentArn,
-            testDomain: adminState.domains.currentTest,
-            testArn: adminState.domains.currentTestArn
-          })
-          availableDomains.current.push({
-            domain: adminState.domains.base,
-            testDomain: adminState.domains.baseTest,
-          })
+          const domains = [{
+              domain: adminState.domains.current,
+              arn: adminState.domains.currentArn,
+              testDomain: adminState.domains.currentTest,
+              testArn: adminState.domains.currentTestArn
+            },
+            ...adminState.availableDomains,
+            {
+              domain: adminState.domains.base,
+              testDomain: adminState.domains.baseTest,
+            }]
+          setAvailableDomains(domains)
         }
       }
-      if ( ! deepEqual(adminState.capturedLogs, capturedLogs.current)) {
+      if ( ! deepEqual(adminState.capturedLogs, capturedLogs)) {
         if (adminState.capturedLogs && adminState.capturedLogs.length) {
-          capturedLogs.current = adminState.capturedLogs
+          setCapturedLogs(adminState.capturedLogs)
         }
       }
     }
@@ -577,17 +577,15 @@ function App() {
               label={LIST_DOMAIN_TOOLTIP}
             >
               <Select size='sm' m='2px' border='none' color='accentText'
-                // Current domain should always be first in list
-                //defaultValue={availableDomains.current ? availableDomains.current.indexOf(adminDomains.current.current) : null}
                 disabled={locked}
                 onFocus={async ev => {
                   await controller.sendCommand('getAvailableDomains')
                 }}
                 onChange={ev => {
-                  setDomain(availableDomains.current[ev.target.value])
+                  setDomain(availableDomains[ev.target.value])
                 }}
               >
-                {availableDomains.current.map((listValue, index) => {
+                {availableDomains.map((listValue, index) => {
                   return <option key={index} value={index}>{listValue.domain}</option>
                 })}
               </Select>
@@ -655,7 +653,7 @@ function App() {
                 tooltip={{ text: BUTTON_CAPTURE_LOGS, placement: 'right-end' }}
                 isLoading={adminDisplay.capturingLogs && !advancedMode} loadingText='Capturing...'
                 isDisabled={!authenticated || locked}/>
-            {capturedLogs.current.length > 0 ?
+            {capturedLogs.length > 0 ?
               <Popover placement='top-end' gutter={20}>
                 {({ onClose }) => {
                   return <><PopoverTrigger>
@@ -670,7 +668,7 @@ function App() {
                       <PopoverBody>
                         <Text>{BUTTON_DOWNLOAD_LOGS_1}</Text>
                         <VStack spacing={0} align='stretch' margin='0.5em 0'>
-                          {capturedLogs.current.map(logFile => {
+                          {capturedLogs.map(logFile => {
                             return <Link key={logFile.url} href={logFile.url} target='_blank'>{logFile.name}</Link>
                           })}
                         </VStack>

--- a/adminUi/src/ChangingDomain.js
+++ b/adminUi/src/ChangingDomain.js
@@ -1,0 +1,20 @@
+import React, { } from 'react';
+import {
+    HStack, Spinner, Box,
+    ModalContent, ModalHeader, ModalBody
+} from '@chakra-ui/react'
+
+/**  */
+export default function ChangingDomain({id}) {
+  return <ModalContent>
+    <ModalHeader>
+      <HStack spacing='5px' align='center'>
+        <Box>Changing Domain</Box>
+        <Box><Spinner size='sm'/></Box>
+      </HStack>
+    </ModalHeader>
+    <ModalBody>
+      Switching site to the new domain...
+    </ModalBody>
+  </ModalContent>
+}

--- a/adminUi/src/Controller.js
+++ b/adminUi/src/Controller.js
@@ -71,6 +71,8 @@ export default class Controller {
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
       // Skip page update if the etag has not changed since the last response (ie. must be cached)
+      // TODO: Seems like AWS is always returning 304 now, as expected, when ETag matches?  Maybe this was a workaround
+      // for a prior server-side bug?  Can likely remove this code and just check for 304 response?
       const etag = response.headers.get('etag')
       if (this.lastETag === null || etag !== this.lastETag) {
         this.lastETag = etag

--- a/build-template.sh
+++ b/build-template.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+wdir=$(pwd)
+
+# Initial build machine setup:
+# npm i handlebars -g
+
+echo Build customized CFN provisioning template versions and copy to target
+cd build
+npm run build-dev
+mv AuthorSite.template $wdir/target/AutoSite
+mv AuthorSite-domain.template $wdir/target/AutoSite
+mv AuthorSite-subdomain.template $wdir/target/AutoSite
+cd $wdir

--- a/build.sh
+++ b/build.sh
@@ -50,3 +50,11 @@ npm run build
 cd build
 zip -qr $wdir/target/AutoSite/provision/adminui.zip *
 cd $wdir
+
+echo Build customized CFN provisioning template versions and copy to target
+cd build
+npm run build
+mv AuthorSite.template $wdir/target/AutoSite
+mv AuthorSite-domain.template $wdir/target/AutoSite
+mv AuthorSite-subdomain.template $wdir/target/AutoSite
+cd $wdir

--- a/build/index.js
+++ b/build/index.js
@@ -6,7 +6,10 @@ async function main() {
   const args = process.argv.slice(2);
   const templateFilePath = args[0]
   const sourceBucket = args[1]
+<<<<<<< HEAD
   const version = args[2] || ''  // Default version to empty string
+=======
+>>>>>>> 8eadeb1 (Start adding server functions for editing site domain on the fly.)
 
   const templateSource = await Fs.readFile(templateFilePath)
   const template = Handlebars.compile(templateSource.toString());

--- a/build/index.js
+++ b/build/index.js
@@ -6,11 +6,7 @@ async function main() {
   const args = process.argv.slice(2);
   const templateFilePath = args[0]
   const sourceBucket = args[1]
-<<<<<<< HEAD
   const version = args[2] || ''  // Default version to empty string
-=======
->>>>>>> 8eadeb1 (Start adding server functions for editing site domain on the fly.)
-
   const templateSource = await Fs.readFile(templateFilePath)
   const template = Handlebars.compile(templateSource.toString());
 

--- a/edge/admin.js
+++ b/edge/admin.js
@@ -215,6 +215,8 @@ const postCommand = async (aws, req, adminBucket, adminUiBucket, arnPrefix) => {
     if (body) {
       params = JSON.parse(body.toString())
     }
+    params.edgeRegion = process.env['AWS_REGION']
+    //
     switch (command) {
       case 'validate':
         ret = {

--- a/edge/admin.js
+++ b/edge/admin.js
@@ -52,6 +52,7 @@ exports.handler = async (event, context) => {
   const aws = new AwsUtils({
     files: null,  // Not needed (though perhaps this suggests we need two different modules)
     s3: new AWS.S3(),
+    cf: new AWS.CloudFront(),
     sqs: new AWS.SQS(),
     stateQueueUrl: `https://sqs.${targetRegion}.amazonaws.com/${awsAccountId}/${rootName}.fifo`
   })

--- a/edge/admin.js
+++ b/edge/admin.js
@@ -260,10 +260,13 @@ const postCommand = async (aws, req, adminBucket, adminUiBucket, arnPrefix) => {
       case 'setSiteDomain':
         ret = invokeAdminWorker(command, arnPrefix + '-admin-worker', params)
         break
+      case 'captureLogs':
+        ret = invokeAdminWorker(command, arnPrefix + '-admin-worker', params)
+        break
       default:
         ret = {
           status: '404',
-          statusDescription: `Unknown admin acion: ${command}`
+          statusDescription: `Unknown admin action: ${command}`
         }
     }
     //console.log(`Return: ${JSON.stringify(ret)}`)

--- a/edge/admin.js
+++ b/edge/admin.js
@@ -254,6 +254,12 @@ const postCommand = async (aws, req, adminBucket, adminUiBucket, arnPrefix) => {
       case 'setPassword':
         ret = invokeAdminWorker(command, arnPrefix + '-admin-worker', params)
         break
+      case 'getAvailableDomains':
+        ret = invokeAdminWorker(command, arnPrefix + '-admin-worker', params)
+        break
+      case 'setSiteDomain':
+        ret = invokeAdminWorker(command, arnPrefix + '-admin-worker', params)
+        break
       default:
         ret = {
           status: '404',

--- a/edge/admin.js
+++ b/edge/admin.js
@@ -10,9 +10,9 @@ const MaxAuthFailedAttempts = 10
 
 const CONTENT_ROOT_PATH = '/admin/site-content/'
 
-// When run in rapid succession, AWS may retain some state between executions so we defined some
-// globals where it would be useful to retain state.
-let stateCache = {}
+// When run in rapid succession, AWS may retain some state between executions so we have the opportunity to cache
+// some READ ONLY state. NOTE: Since different physical machines may handle successive lambda executions, this
+// pattern is NOT safe for use with read/write cache.
 let editorsList = null
 
 /**
@@ -108,8 +108,22 @@ exports.handler = async (event, context) => {
       // pages will just get the current state returned.
       const queryObj = new URLSearchParams(req.querystring)
       if (queryObj.get('active') === 'true') {
-        const resp = await aws.updateAdminStateFromQueue(stateCache, adminBucket, adminUiBucket)
-        if (resp) { return resp }
+        // Process queued state messages
+        const resp = await aws.updateAdminStateFromQueue(adminBucket, adminUiBucket)
+        // Async invoke a check of CloudFront Distro state so we can give feedback to the user about when it's
+        // possible to request changes.
+        invokeAdminWorker('checkCfDistroState', arnPrefix + '-admin-worker', {
+          domains: {
+            main: resp.state.state.domains.base,
+            test: resp.state.state.domains.baseTest
+          }
+        })
+        if (resp.error) {
+          return {
+            status: '500',
+            statusDescription: resp.error
+          }
+        }
       }
     }
     else if (req.uri.indexOf('/admin/lock') === 0) {

--- a/edge/awsUtils.js
+++ b/edge/awsUtils.js
@@ -675,5 +675,39 @@ AwsUtils.prototype.updateSiteDomain = async function(domain) {
   }
 }
 
+/** Get the latest 50 log streams details for the given group name. */
+AwsUtils.prototype.getLogStreams = async function(logGroupName) {
+  const ret = await this.logs.describeLogStreams({
+    logGroupName: logGroupName,
+    orderBy: 'LastEventTime',
+    descending: true,
+    // limit: 50 // default is up to 50 items.
+    // nextToken:  // token to get the next 50 items (See if we need >50 groups under expected volume?)
+  }).promise
+  ret.logStreams
+  //ret.nextToken
+  return ret.logStreams.map(stream => {
+    return {
+      name: stream.logStreamName,
+      firstEventTs: stream.firstEventTimestamp,
+      lastEventTs: stream.firstEventTimestamp
+    }
+  })
+}
+
+/** Get the events from the given log stream, limited to the given start/end timestamps. */
+AwsUtils.prototype.getLogEvents = async function(logGroupName, logStreamName, startTs, endTs) {
+  const ret = await this.logs.getLogEvents({
+    logGroupName: logGroupName,
+    logStreamName: logStreamName,
+    startFromHead: false,  // Must be true is nextToken is provided.
+    startTime: startTs,
+    endTime: endTs
+    // limit: 50 // default is up to 1MB, or 100k items
+    // nextToken:  // token to get the next 50 items (See if we need >50 groups under expected volume?)
+  }).promise
+  return ret.events
+}
+
 //
 module.exports = AwsUtils

--- a/edge/awsUtils.js
+++ b/edge/awsUtils.js
@@ -666,7 +666,7 @@ AwsUtils.prototype.listCertificates = async function() {
   }).promise()
   const list = ret.CertificateSummaryList
   return list
-    .filter(p => p.inUse)
+    .filter(p => !(p.InUse))
     .map(p => {
       return {
         arn: p.CertificateArn,
@@ -680,7 +680,7 @@ AwsUtils.prototype.updateAvailableDomains = async function(domains) {
   try {
     const msg = {
       time: Date.now(),
-      setAvailableDomains: domains
+      availableDomains: domains
     }
     const ret = await this.sqs.sendMessage({
       QueueUrl: this.stateQueueUrl,

--- a/edge/awsUtils.js
+++ b/edge/awsUtils.js
@@ -711,9 +711,10 @@ AwsUtils.prototype.updateSiteDomain = async function(domain) {
 }
 
 /** Get the latest 50 log streams details for the given group name. */
-AwsUtils.prototype.getLogStreams = async function(logGroupName) {
+AwsUtils.prototype.getLogStreams = async function(logGroupName, edge) {
   try {
-    const ret = await this.logs.describeLogStreams({
+    const logsClient = edge ? this.logsEdge : this.logs
+    const ret = await logsClient.describeLogStreams({
       logGroupName: logGroupName,
       orderBy: 'LastEventTime',
       descending: true,
@@ -739,8 +740,9 @@ AwsUtils.prototype.getLogStreams = async function(logGroupName) {
 }
 
 /** Get the events from the given log stream, limited to the given start/end timestamps. */
-AwsUtils.prototype.getLogEvents = async function(logGroupName, logStreamName, startTs, endTs) {
-  const ret = await this.logs.getLogEvents({
+AwsUtils.prototype.getLogEvents = async function(logGroupName, edge, logStreamName, startTs, endTs) {
+  const logsClient = edge ? this.logsEdge : this.logs
+  const ret = await logsClient.getLogEvents({
     logGroupName: logGroupName,
     logStreamName: logStreamName,
     startFromHead: false,  // Must be true is nextToken is provided.

--- a/edge/awsUtils.js
+++ b/edge/awsUtils.js
@@ -549,8 +549,8 @@ const _mergeState = (state, logs, message) => {
   if (message.siteDomain) {
     stateUpdated = true
     console.log(`Update site domain ${JSON.stringify(message.siteDomain)}}`)
-    state.domains.base = message.siteDomain.base
-    state.domains.test = message.siteDomain.test
+    state.domains.current = message.siteDomain.current
+    state.domains.currentTest = message.siteDomain.currentTest
   }
   //
   return { logsUpdated: logsUpdated, stateUpdated: stateUpdated }
@@ -654,20 +654,26 @@ AwsUtils.prototype.updateAvailableDomains = async function(domains) {
     }).promise()
     return ret
   } catch (error) {
-    console.error(`Failed to send templates update: ${JSON.stringify(error)}`)
+    console.error(`Failed to send available domains update: ${JSON.stringify(error)}`)
   }
 }
 
-AwsUtils.prototype.listDomainsInUse = async function() {
-  if ( ! this.acm) {
-    throw new Error("Certificate manager service not initilaized.")
+AwsUtils.prototype.updateSiteDomain = async function(domain) {
+  try {
+    const msg = {
+      time: Date.now(),
+      siteDomain: domain
+    }
+    const ret = await this.sqs.sendMessage({
+      QueueUrl: this.stateQueueUrl,
+      MessageBody: JSON.stringify(msg),
+      MessageGroupId: 'admin'
+    }).promise()
+    return ret
+  } catch (error) {
+    console.error(`Failed to send site domain update: ${JSON.stringify(error)}`)
   }
-
-
-
-
 }
-
 
 //
 module.exports = AwsUtils

--- a/edge/awsUtils.js
+++ b/edge/awsUtils.js
@@ -24,12 +24,14 @@ function AwsUtils(options) {
   if (!(this instanceof AwsUtils)) {
     return new AwsUtils(options);
   }
+  //console.log('AWS Options:', options)
   this.files = options.files
   this.s3 = options.s3
   this.sqs = options.sqs
   this.stateQueueUrl = options.stateQueueUrl
   this.cf = options.cf
   this.acm = options.acm
+  this.r53 = options.r53
   this.logs = options.logs
   this.maxAgeBrowser = options.maxAgeBrowser || 60 * 60 * 24  // 24 hours
   this.maxAgeCloudFront = options.maxAgeCloudFront || 60  // 60 seconds

--- a/edge/package-lock.json
+++ b/edge/package-lock.json
@@ -8,10 +8,12 @@
       "name": "edge",
       "version": "1.0.0",
       "bundleDependencies": [
+        "fast-deep-equal",
         "mime"
       ],
       "license": "ISC",
       "dependencies": {
+        "fast-deep-equal": "^3.1.3",
         "mime": "^3.0.0"
       },
       "devDependencies": {
@@ -871,7 +873,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "inBundle": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3156,8 +3158,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/edge/package.json
+++ b/edge/package.json
@@ -18,9 +18,11 @@
     "npm-pack-zip": "^1.3.0"
   },
   "dependencies": {
+    "fast-deep-equal": "^3.1.3",
     "mime": "^3.0.0"
   },
   "bundleDependencies": [
+    "fast-deep-equal",
     "mime"
   ]
 }

--- a/generators/authorsite/package-lock.json
+++ b/generators/authorsite/package-lock.json
@@ -40,7 +40,8 @@
         "universal-cookie",
         "walk",
         "webpack",
-        "yaml"
+        "yaml",
+        "fast-deep-equal"
       ],
       "license": "ISC",
       "dependencies": {
@@ -50,6 +51,7 @@
         "axios": "^1.1.3",
         "babel-loader": "^8.2.5",
         "echo-loader": "0.0.1",
+        "fast-deep-equal": "^3.1.3",
         "filecompare": "^1.0.4",
         "fs-extra": "^10.1.0",
         "handlebars": "^4.7.7",

--- a/generators/authorsite/package.json
+++ b/generators/authorsite/package.json
@@ -52,6 +52,7 @@
     "axios": "^1.1.3",
     "babel-loader": "^8.2.5",
     "echo-loader": "0.0.1",
+    "fast-deep-equal": "^3.1.3",
     "filecompare": "^1.0.4",
     "fs-extra": "^10.1.0",
     "handlebars": "^4.7.7",
@@ -135,6 +136,7 @@
     "universal-cookie",
     "walk",
     "webpack",
-    "yaml"
+    "yaml",
+    "fast-deep-equal"
   ]
 }

--- a/provisioner/index.js
+++ b/provisioner/index.js
@@ -64,6 +64,13 @@ const cfnCreateHandler = async (params) => {
       })
     }
 
+    const domains = {
+      base: params.BaseDomain,
+      baseTest: params.BaseDomainTest,
+      current: params.DomainName || params.BaseDomain,
+      currentTest: params.DomainNameTest || params.BaseDomainTest
+    }
+
     // Generate default admin data in Admin UI bucket.
     //    This data object will be replaced/updated in S3 by other admin processes as needed.
     console.log('Create default admin state file.')
@@ -74,6 +81,7 @@ const cfnCreateHandler = async (params) => {
       ContentType: 'application/json',
       Body: Buffer.from(JSON.stringify({
         generator: params.SiteGenerator,
+        domains: domains,
         templates: templates,
         config: {},
         display: {}
@@ -99,12 +107,7 @@ const cfnCreateHandler = async (params) => {
     }))
 
     // Add default index.html to site buckets with redirect to the admin site
-    let siteUrl = null
-    if (params.DomainName) {
-      siteUrl = `https://${params.DomainName}/admin/index`
-    } else {
-      siteUrl = '/admin/index'
-    }
+    let siteUrl = `https://${domains.current}/admin/index`
     const indexPage = `
       <!DOCTYPE html>
       <html>

--- a/provisioner/index.js
+++ b/provisioner/index.js
@@ -65,10 +65,14 @@ const cfnCreateHandler = async (params) => {
     }
 
     const domains = {
+      dist: params.WebCache,
+      distTest: params.TestWebCache,
       base: params.BaseDomain,
       baseTest: params.BaseDomainTest,
       current: params.DomainName || params.BaseDomain,
-      currentTest: params.DomainNameTest || params.BaseDomainTest
+      currentArn: params.DomainCertArn,
+      currentTest: params.DomainNameTest || params.BaseDomainTest,
+      currentTestArn: params.DomainCertTestArn
     }
 
     // Generate default admin data in Admin UI bucket.


### PR DESCRIPTION
Main features:
 - A dropdown list in the titlebar showing all available (unused) domain pairs (main and test) in this account that can be assigned to this site. Includes the CloudFront default domain so the custom domain can be removed (generally for use by another site)
 -  A button in the footer to capture all CloudWatch logs for this site from the past hour. The captured logs are collected in a single file which is made available for download for 1 hour following the capture.

Bug Fixes
 - Removed some very old cache code from the main 'edge/admin' lambda that was occasionally causing admin state overwrites :( 
 - Some general refactoring and cleanup of the UI.
 - AWS now requires: ObjectOwnership: BucketOwnerPreferred
 - Split Admin roles between edge/state handler and Worker, since the have very different jobs.